### PR TITLE
비밀번호 찾기 기능에 Axios 통신 추가

### DIFF
--- a/petharmony/src/login/components/find/FindAccount.jsx
+++ b/petharmony/src/login/components/find/FindAccount.jsx
@@ -127,7 +127,7 @@ const FindAccount = () => {
                     const date = new Date(responseData.createDate);
                     setFormattedDate(date.toISOString().slice(0, 10).replace(/-/g, '.'));
                 }
-                
+
                 if (responseData.email) {
                     setIsFinishId(true);
                 } else {
@@ -155,7 +155,11 @@ const FindAccount = () => {
             const response = await axios.post('http://localhost:8080/api/public/send-email', emailData);
 
             if (response.status === 200) {
-                setIsFinishPassword(true);
+                if (response.data === "임시 비밀번호가 이메일로 발송되었습니다.") {
+                    setIsFinishPassword(true);
+                } else {
+                    setFailMsg(response.data);
+                }
             } else {
                 setFailMsg(response.data);
             }

--- a/petharmony/src/login/components/find/FindAccount.jsx
+++ b/petharmony/src/login/components/find/FindAccount.jsx
@@ -146,17 +146,20 @@ const FindAccount = () => {
         setEmail(e.target.value);
     };
 
-    const hanldeSendEmail = () => {
-        const success = true; // 하드코딩
-        const isExistEmail = true; // 하드코딩
+    const hanldeSendEmail = async () => {
+        const emailData = {
+            email: email
+        };
 
-        if (success) {
-            if (isExistEmail) {
+        try {
+            const response = await axios.post('http://localhost:8080/api/public/send-email', emailData);
+
+            if (response.status === 200) {
                 setIsFinishPassword(true);
             } else {
-                setFailMsg("가입되지 않은 이메일입니다.");
+                setFailMsg(response.data);
             }
-        } else {
+        } catch {
             setFailMsg("이메일 전송에 실패하였습니다.")
         }
     };


### PR DESCRIPTION
회원 계정 찾기(비밀번호 찾기) 기능에 이메일 전송을 위한 Axios 통신 루직을 추가했습니다.
사용자가 이메일을 입력하면 서버로 해당 이메일 주소로 임시 비밀번호를 요청하는 기능을 구현했습니다.
서버로부터 성공 응답을 받으면
"임시 비밀번호가 이메일로 발송되었습니다." 메시지를 확인하고, 비밀번호 찾기 완료 화면이 표시됩니다.
서버에서 실패 응답을 받거나 오류가 발생할 경우,
사용자에게 적절한 오류 메시지를 출력합니다.